### PR TITLE
Revert "Bump chardet from 3.0.4 to 4.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alembic==1.4.3
 certifi==2020.12.5
 cffi==1.14.4
-chardet==4.0.0
+chardet==3.0.4
 click==7.1.2
 codecov==2.1.10
 coverage==5.3


### PR DESCRIPTION
Reverts sendahug/send-hug-backend#41
Seeing as Requests requires chardet<4 right now, this needs to be reverted. Once the new version comes out (psf/requests#5688), chardet can be upgraded.