### PR TITLE
Deleted PyOpenSSL dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ py-vapid==1.9.0
 pyasn1==0.4.8
 pycparser==2.21
 pycryptodome==3.16.0
-pyOpenSSL==22.1.0
 python-dateutil==2.8.2
 python-editor==1.0.4
 python-jose==3.3.0


### PR DESCRIPTION
Since we don't seem to be using this dependency at all, it's about time it's removed entirely.
