### PR TITLE
feature: Added GitHub Actions dependencies to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,15 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: pywebpush
-    versions:
-    - 1.12.0
-  - dependency-name: alembic
-    versions:
-    - 1.5.6
-  - dependency-name: cryptography
-    versions:
-    - 3.4.1
-    - 3.4.4
-    - 3.4.5
   rebase-strategy: auto
+  commit-message:
+    prefix: "deps:"
+
+# Maintain dependencies for GitHub Actions
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  commit-message:
+    prefix: "deps:"


### PR DESCRIPTION
Long overdue update to the Dependabot config to include GitHub Actions dependencies and delete old "ignore" packages.