### PR TITLE
change: Switch CircleCI to only run on PRs to dev in the UI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,12 +67,6 @@ jobs:
 # Once it's done, run codecov to upload test coverage
 workflows:
   test:
-    when:
-      or:
-        - << pipeline.parameters.run_workflow_build >>
-        - equal: [ live, << pipeline.git.branch >> ]
-        - equal: [ staging, << pipeline.git.branch >> ]
-        - equal: [ dev, << pipeline.git.branch >> ]
     jobs:
       - lint
       - build

--- a/.github/workflows/triggerbuild.yml
+++ b/.github/workflows/triggerbuild.yml
@@ -4,10 +4,12 @@ name: Trigger Build
 # Controls when the action will run. Triggers the workflow on pull request
 # events but only for the master branch
 on:
-  pull_request:
-    branches: [ dev, staging, live ]
-  pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [testing_disabling_the_workflow_so_making_up_unlikely_branch]
+  # pull_request:
+  #   branches: [ dev, staging, live ]
+  # pull_request_target:
+  #   types: [opened, synchronize, reopened, ready_for_review]
 
 # Trigger CircleCI build via the API
 jobs:

--- a/.github/workflows/triggerbuild.yml
+++ b/.github/workflows/triggerbuild.yml
@@ -4,12 +4,10 @@ name: Trigger Build
 # Controls when the action will run. Triggers the workflow on pull request
 # events but only for the master branch
 on:
-  push:
-    branches: [testing_disabling_the_workflow_so_making_up_unlikely_branch]
-  # pull_request:
-  #   branches: [ dev, staging, live ]
-  # pull_request_target:
-  #   types: [opened, synchronize, reopened, ready_for_review]
+  pull_request:
+    branches: [ dev, staging, live ]
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 # Trigger CircleCI build via the API
 jobs:
@@ -17,12 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: python:3.9.1
-    # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]".
-    # Otherwise, clone it normally.
-    # From here: https://hugo.alliau.me/2021/05/04/migration-to-github-native-dependabot-solutions-for-auto-merge-and-action-secrets/#share-your-secrets-with-dependabot
-    if: |
-      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    # Using this to essentially disable the workflow for now.
+    # TODO: Once we've tested the CircleCI "run on pull reqeusts only"
+    # setting enough and are happy with it, this file can be deleted.
+    if: (github.event_name == 'octocat')
     steps:
       - run: >-
             curl -X POST "https://circleci.com/api/v2/project/gh/sendahug/send-hug-backend/pipeline"


### PR DESCRIPTION
Leaving this as is until tomorrow; want to see that it still works fine with dependabot and then we can remove that workflow entirely.