### PR TITLE
Revert "build(deps-dev): bump pytest from 8.0.2 to 8.1.0"

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,6 +4,6 @@ mypy==1.8.0
 types-python-jose==3.3.4.20240106
 types-Flask-Cors==4.0.0.20240106
 
-pytest==8.1.0
+pytest==8.0.2
 pytest-mock==3.12.0
 pytest-cov==4.1.0


### PR DESCRIPTION
Reverts sendahug/send-hug-backend#571.

Apparently this version was yanked, so it's better to switch back to the previous version.