### PR TITLE
change: Updated the queries' syntax for the SQLAlchemy 2.0 syntax change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-#### Changes
+#### Changes
 
 - Updated the syntax of all `select` queries for SQLAlchemy 2. Previously, we were using SQLAlchemy 1's `Query` API, which is now deprecated. Now, we use `session.scalar` and `session.scalars` for selecting single and multiple items (respectively). ([#595](https://github.com/sendahug/send-hug-backend/pull/595))
 - Updated the syntax of all paginated queries to the updated Flask-SQLAlchemy 3 / SQLAlchemy 2 syntax. Previously, we were using `Model.query.paginate()`. This has now been replaced by `db.paginate` ([#595](https://github.com/sendahug/send-hug-backend/pull/595)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+#### Changes
+
+- Updated the syntax of all `select` queries for SQLAlchemy 2. Previously, we were using SQLAlchemy 1's `Query` API, which is now deprecated. Now, we use `session.scalar` and `session.scalars` for selecting single and multiple items (respectively). ([#595](https://github.com/sendahug/send-hug-backend/pull/595))
+- Updated the syntax of all paginated queries to the updated Flask-SQLAlchemy 3 / SQLAlchemy 2 syntax. Previously, we were using `Model.query.paginate()`. This has now been replaced by `db.paginate` ([#595](https://github.com/sendahug/send-hug-backend/pull/595)).
+- The helper method for bulk deleting items (posts/messages/threads) now uses SQLAlchemy's delete method instead of the old query().delete() method, which is cleaner and faster than deleting items manually via the ORM ([#595](https://github.com/sendahug/send-hug-backend/pull/595)).
+- The helper method for bulk updating items now only commits the session once. Previously, it was doing it for every object, but this is unnecessary and wastes time and resources. Now, the session is committed once all objects are updated (in the relevant endpoint), and we only loop over the updated objects to format them and return the JSON data ([#595](https://github.com/sendahug/send-hug-backend/pull/595)).
+
+### 2024-03-31
+
 #### Features
 
 - Added type hints to all SQLAlchemy models ([#593](https://github.com/sendahug/send-hug-backend/pull/593)).
@@ -18,7 +27,7 @@
 - Replaced the deprecated `backref` parameter in the SQLAlchemy relationship definitions with the current `back_populates` parameter ([#593](https://github.com/sendahug/send-hug-backend/pull/593)).
 - Several SQLAlchemy queries were incorrectly using Python operators (or, and) as part of their `WHERE` clause instead of the bitwise operators or the dedicated SQLAlchemy methods. This meant that in some instances the second part of a query's filter was ignored. Now, all queries use the correct SQLAlchemy helper methods (`or_`, `and_`) for filtering ([#593](https://github.com/sendahug/send-hug-backend/pull/593)).
 
-### 2024-03-29
+### 2024-03-30
 
 #### Chores
 

--- a/create_app.py
+++ b/create_app.py
@@ -1486,11 +1486,17 @@ def create_app(db_path: str = database_path) -> Flask:
 
         # If the item reported is a user
         if report.type.lower() == "user":
+            if not updated_report.get("userID", None):
+                abort(422)
+
             reported_item = db.session.scalar(
                 db.select(User).filter(User.id == updated_report["userID"])
             )
         # If the item reported is a post
         else:
+            if not updated_report.get("postID", None):
+                abort(422)
+
             reported_item = db.session.scalar(
                 db.select(Post).filter(Post.id == updated_report["postID"])
             )

--- a/create_app.py
+++ b/create_app.py
@@ -340,7 +340,7 @@ def create_app(db_path: str = database_path) -> Flask:
                 )
 
             # Otherwise get the open report and close it
-            open_report: Optional[Report] = db.session.scalar(
+            open_report = db.session.scalar(
                 db.select(Report).filter(Report.id == updated_post["closeReport"])
             )
 
@@ -1141,7 +1141,7 @@ def create_app(db_path: str = database_path) -> Flask:
 
         # If a new thread was created and the database session ended, we need
         # to get the logged user's data again.
-        logged_user: User = db.one_or_404(
+        logged_user = db.one_or_404(
             db.select(User).filter(User.auth0_id == token_payload["sub"])
         )
 

--- a/models/db_helpers.py
+++ b/models/db_helpers.py
@@ -150,8 +150,9 @@ def update_multiple(
 
     # Try to update the object in the database
     try:
+        db.session.commit()
+
         for obj in objs:
-            db.session.commit()
             updated_objects.append(obj.format())
     # If there's a database error
     except (DataError, IntegrityError) as err:

--- a/models/models.py
+++ b/models/models.py
@@ -25,6 +25,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from datetime import datetime
 import os
 import json
 from typing import List, Optional
@@ -107,7 +108,7 @@ class User(db.Model):  # type: ignore[name-defined]
     blocked: Mapped[bool] = db.Column(db.Boolean, nullable=False, default=False)
     release_date: Mapped[Optional[DateTime]] = db.Column(db.DateTime)
     open_report: Mapped[bool] = db.Column(db.Boolean, nullable=False, default=False)
-    last_notifications_read: Mapped[Optional[DateTime]] = db.Column(db.DateTime)
+    last_notifications_read: Mapped[Optional[datetime]] = db.Column(db.DateTime)
     auto_refresh: Mapped[Optional[bool]] = db.Column(db.Boolean, default=True)
     refresh_rate: Mapped[Optional[int]] = db.Column(db.Integer, default=20)
     push_enabled: Mapped[Optional[bool]] = db.Column(db.Boolean, default=False)

--- a/tests/test_db_helpers.py
+++ b/tests/test_db_helpers.py
@@ -168,7 +168,9 @@ def test_update_multiple_no_errors(test_db, db_helpers_dummy_data):
         },
     ]
 
-    posts = test_db.session.query(Post).filter(Post.id < 3).order_by(Post.id).all()
+    posts = test_db.session.scalars(
+        test_db.select(Post).filter(Post.id < 3).order_by(Post.id)
+    ).all()
     original_post_1_text = posts[0].text
     posts[0].text = "new test"
     original_post_2_hugs = posts[1].given_hugs
@@ -182,7 +184,9 @@ def test_update_multiple_no_errors(test_db, db_helpers_dummy_data):
 
 
 def test_update_multiple_error(test_db):
-    posts = test_db.session.query(Post).filter(Post.id < 3).order_by(Post.id).all()
+    posts = test_db.session.scalars(
+        test_db.select(Post).filter(Post.id < 3).order_by(Post.id)
+    ).all()
     posts[0].text = "hello"
     posts[1].user_id = 1000
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -644,7 +644,7 @@ def test_empty_mailbox_as_admin(app_client, test_db, user_headers, dummy_users_d
 
     assert response_data["success"] is True
     assert response.status_code == 200
-    assert response_data["deleted"] == 3
+    assert response_data["deleted"] == 2
     assert response_data["userID"] == 4
 
 


### PR DESCRIPTION
**Description**

All the query code still uses the SQLAlchemy 1 syntax (`Model.query` or `session.query`). However, the query API is deprecated and the [Flask-SQLAlchemy docs](https://flask-sqlalchemy.palletsprojects.com/en/3.1.x/queries/) have been updated to include information about the new syntax that should be used from now on.

Apologise in advance about the size of this, apparently we had more of these than I thought...

**Issue link**

--

**Expected behavior**

We should be using the new syntax instead of the deprecated one.

**Your solution**

I've replaced all `Model.query` and `session.query` with the new, correct way of querying for data. This includes:
- Paginated queries now use the new `db.paginate` (as per the guidance in the [docs](https://flask-sqlalchemy.palletsprojects.com/en/3.1.x/pagination/)).
- Regular select queries now use the `session.scalars` and `session.scalar` for multiple and single selects (respectively).
- The helper method for bulk deleting items (posts/messages/threads) now uses SQLAlchemy's `delete` method instead of the old `query().delete()` method, which is cleaner and faster than deleting items manually via the ORM (based on [the docs](https://docs.sqlalchemy.org/en/20/tutorial/data_update.html#the-delete-sql-expression-construct)).

**Additional information**

--