### PR TITLE
fix: Deleting messages from thread view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+#### Fixes
+
+- Fixed a bug where users couldn't delete messages from the thread view because there was no handling for deleting messages from threads in the DELETE /messages endpoint ([#596](https://github.com/sendahug/send-hug-backend/pull/596)).
+
+### 2024-03-31
+
 #### Features
 
 - Added type hints to all SQLAlchemy models ([#593](https://github.com/sendahug/send-hug-backend/pull/593)).
@@ -18,7 +24,7 @@
 - Replaced the deprecated `backref` parameter in the SQLAlchemy relationship definitions with the current `back_populates` parameter ([#593](https://github.com/sendahug/send-hug-backend/pull/593)).
 - Several SQLAlchemy queries were incorrectly using Python operators (or, and) as part of their `WHERE` clause instead of the bitwise operators or the dedicated SQLAlchemy methods. This meant that in some instances the second part of a query's filter was ignored. Now, all queries use the correct SQLAlchemy helper methods (`or_`, `and_`) for filtering ([#593](https://github.com/sendahug/send-hug-backend/pull/593)).
 
-### 2024-03-29
+### 2024-03-30
 
 #### Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-#### Fixes
+#### Fixes
 
 - Fixed a bug where users couldn't delete messages from the thread view because there was no handling for deleting messages from threads in the DELETE /messages endpoint ([#596](https://github.com/sendahug/send-hug-backend/pull/596)).
 

--- a/create_app.py
+++ b/create_app.py
@@ -1236,7 +1236,11 @@ def create_app(db_path: str = database_path) -> Flask:
             )
 
         # If the mailbox type is inbox/outbox/thread
-        if isinstance(delete_item, Message) and mailbox_type in ["inbox", "outbox", "thread"]:
+        if isinstance(delete_item, Message) and mailbox_type in [
+            "inbox",
+            "outbox",
+            "thread",
+        ]:
             if delete_item.for_id == request_user.id:
                 delete_item.for_deleted = True
             else:

--- a/create_app.py
+++ b/create_app.py
@@ -1211,12 +1211,12 @@ def create_app(db_path: str = database_path) -> Flask:
                 403,
             )
 
-        # If the mailbox type is inbox
-        if mailbox_type == "inbox":
-            delete_item.for_deleted = True
-        # If the mailbox type is outbox
-        elif mailbox_type == "outbox":
-            delete_item.from_deleted = True
+        # If the mailbox type is inbox/outbox/thread
+        if mailbox_type in ["inbox", "outbox", "thread"]:
+            if delete_item.for_id == request_user.id:
+                delete_item.for_deleted = True
+            else:
+                delete_item.from_deleted = True
         # If the mailbox type is threads
         elif mailbox_type == "threads":
             # Otherwise, if the current user is the thread's user_1, set


### PR DESCRIPTION
**Description**

There's a bug where users can't delete messages from the thread view. Investigation shows it's because there was no handling for a thread in the DELETE `/messages/<mailbox_type>/<item_id>` endpoint; the messages were only updated when users were doing it from their inbox, outbox or threads list.

**Issue link**

--

**Expected behavior**

Users should be able to delete messages from the thread view.

**Your solution**

Added the missing condition to check for a thread and update the given message if the user is looking at a thread.

**Additional information**

--
