### PR TITLE
chore: Updated caching and the codecov orb in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
     default: false
     type: boolean
 orbs:
-  codecov: codecov/codecov@3
+  codecov: codecov/codecov@4.0.1
 
 jobs:
   lint:
@@ -15,8 +15,14 @@ jobs:
           TEST_DATABASE_URL: postgresql://postgres:password@localhost:5432/test_sah?sslmode=disable
     steps:
       - checkout
+      - restore_cache:
+          key: deps1-
       - run: pip3 install -r requirements.txt -r dev_requirements.txt
       - run: pre-commit install
+      - save_cache:
+          key: deps1-{{ checksum "requirements.txt" }}
+          paths:
+            - "/usr/local/lib/python3.10/site-packages"
       - run: pre-commit run --all
       - run: mypy . --exclude 'migrations/' --check-untyped-defs
   build:
@@ -36,7 +42,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: deps1-
       - run: sudo apt-get update
       - run: sudo apt-get install -y postgresql-client
       - run:
@@ -55,9 +61,9 @@ jobs:
           name: Wait for db
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - save_cache:
-          key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: deps1-{{ checksum "requirements.txt" }}
           paths:
-            - "/usr/local/lib/python3.9/site-packages"
+            - "/usr/local/lib/python3.10/site-packages"
       - run:
           command: |
             pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## Unreleased
 
-#### Chores
-
-- Updated the version of the Codecov orb we use in CI to the latest version ([#597](https://github.com/sendahug/send-hug-backend/pull/597)).
-- Updated the way caching works in the Circle CI workflow. Previously, the cache and restore operations used a specific key made of the branch name and the package-lock's checksum. This meant that since it was specific to each branch, we were hardly ever using the cache we built. Instead, we just kept adding to it. This update ensures we actually use the cache, which should also lower the cache-storing costs ([#597](https://github.com/sendahug/send-hug-backend/pull/597)).
-
 ### 2024-04-03
 
 #### Chores

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+#### Chores
+
+- Updated the version of the Codecov orb we use in CI to the latest version ([#597](https://github.com/sendahug/send-hug-backend/pull/597)).
+- Updated the way caching works in the Circle CI workflow. Previously, the cache and restore operations used a specific key made of the branch name and the package-lock's checksum. This meant that since it was specific to each branch, we were hardly ever using the cache we built. Instead, we just kept adding to it. This update ensures we actually use the cache, which should also lower the cache-storing costs ([#597](https://github.com/sendahug/send-hug-backend/pull/597)).
+
+### 2024-04-02
+
 #### Fixes
 
 - Fixed a bug where users couldn't delete messages from the thread view because there was no handling for deleting messages from threads in the DELETE /messages endpoint ([#596](https://github.com/sendahug/send-hug-backend/pull/596)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-#### Chores
+#### Chores
 
 - Updated the version of the Codecov orb we use in CI to the latest version ([#597](https://github.com/sendahug/send-hug-backend/pull/597)).
 - Updated the way caching works in the Circle CI workflow. Previously, the cache and restore operations used a specific key made of the branch name and the package-lock's checksum. This meant that since it was specific to each branch, we were hardly ever using the cache we built. Instead, we just kept adding to it. This update ensures we actually use the cache, which should also lower the cache-storing costs ([#597](https://github.com/sendahug/send-hug-backend/pull/597)).

--- a/changelog/pr597.json
+++ b/changelog/pr597.json
@@ -1,0 +1,13 @@
+{
+  "pr_number": 597,
+  "changes": [
+    {
+      "change": "Chores",
+      "description": "Updated the version of the Codecov orb we use in CI to the latest version."
+    },
+    {
+      "change":"Chores",
+      "description": "Updated the way caching works in the Circle CI workflow. Previously, the cache and restore operations used a specific key made of the branch name and the package-lock's checksum. This meant that since it was specific to each branch, we were hardly ever using the cache we built. Instead, we just kept adding to it. This update ensures we actually use the cache, which should also lower the cache-storing costs."
+    }
+  ]
+}


### PR DESCRIPTION
**Description**

The codecov orb we use in CI is severely outdated. Our caching in CI also relies on exact matches for a file's checksum, which doesn't really allow us to restore from cache.

**Issue link**

--

**Expected behavior**

--

**Your solution**

Updated the orb's version and changed the cache restoration to use partial matches.

**Additional information**

--
