### PR TITLE
fix: Prevent auto-refreshes that are too quick.

### DIFF
--- a/changelog/pr599.json
+++ b/changelog/pr599.json
@@ -1,0 +1,9 @@
+{
+  "pr_number": 599,
+  "changes": [
+    {
+      "change": "Fixes",
+      "description": "Added a missing check in the users' update endpoint to ensure users aren't setting the refresh rate to a too-low rate that crashes the API (due to too many requests)."
+    }
+  ]
+}

--- a/create_app.py
+++ b/create_app.py
@@ -781,6 +781,10 @@ def create_app(db_path: str = database_path) -> Flask:
                 )
 
         # If the user is changing their settings
+        if updated_user.get("autoRefresh") and updated_user.get("refreshRate", 0) < 20:
+            abort(422)
+
+        # If the user is changing their settings
         original_user.auto_refresh = updated_user.get(
             "autoRefresh", original_user.auto_refresh
         )

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -502,6 +502,33 @@ def test_update_admin_settings_as_admin(
     assert updated["refreshRate"] == 60
 
 
+# Attempt to update another user's settings (admin's JWT) - 0 refresh rate
+def test_update_admin_settings_as_admin_invalid_settings(
+    app_client, test_db, user_headers, dummy_users_data, dummy_request_data
+):
+    user = {**dummy_request_data["updated_unblock_user"]}
+    user["id"] = dummy_users_data["admin"]["internal"]
+    user["autoRefresh"] = True
+    user["pushEnabled"] = True
+    user["refreshRate"] = 0
+    response = app_client.patch(
+        f"/users/all/{dummy_users_data['admin']['internal']}",
+        headers=user_headers["admin"],
+        data=json.dumps(user),
+    )
+    response_data = json.loads(response.data)
+
+    get_response = app_client.get(
+        f"/users/all/{dummy_users_data['admin']['internal']}",
+        headers=user_headers["admin"],
+    )
+    get_response_data = json.loads(get_response.data)
+
+    assert response_data["success"] is False
+    assert response.status_code == 422
+    assert get_response_data["user"]["refreshRate"] is None
+
+
 def test_close_report_update_user_as_admin(
     app_client, test_db, user_headers, dummy_users_data, dummy_request_data
 ):


### PR DESCRIPTION
**Description**

Right now it's possible to turn auto-refresh (for notifications) on and set it to a low value (like 0), which then causes the front-end to make non-stop requests to get new notifications. For obvious reasons, that's a massive problem.

**Issue link**

--

**Expected behavior**

The backend should reject a value that's too low (currently set to 20 seconds).

**Your solution**

Added a missing check to ensure that the update is aborted and the user is given an error if they try to set the value to a too-low number.

**Additional information**

--
