### PR TITLE
change: Split report closing from user/post edit.

### DIFF
--- a/API_DOCS.md
+++ b/API_DOCS.md
@@ -278,7 +278,6 @@ For full instructions check the [`backend README`](./backend/README.md)
 **Required Data**: A JSON containing the post's updated data, in the following format:
   - text (String) - The updated post's text.
   - given_hugs (Number) - The updated hugs count.
-  - closeReport (Number) - the ID of the report to close (if there is one). This variable is only needed if the post is edited from the Admin Dashboard.
 
 **Required Permission:** 'patch:my-post' or 'patch:any-post'.
 
@@ -567,7 +566,6 @@ For full instructions check the [`backend README`](./backend/README.md)
   - loginCount (Number) - The user's login count.
   - blocked (Boolean) - Whether or not the user is blocked.
   - releaseDate (Date) - When the user will be unblocked. Must be in request data if 'blocked' is set to true in the request data.
-  - closeReport (Number) - the ID of the report to close (if the edit request was sent from the Admin Dashboard).
 
 **Required Permission:** 'patch:user' or 'patch:any-user'.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 #### Breaking Changes
 
-- The authorisation process has been rewritten to use the new roles and permissions system. This includes: 
+- The authorisation process has been rewritten to use the new roles and permissions system. This includes:
 	- The `requires_auth` decorator now fetches the currently-logged in user and checks the required permissions against the user's permissions in our database in all endpoints except for the create user endpoint (as the user doesn't exist yet).
 	- The old process for updating a new user's role from NewUser to User was deleted. Since the only endpoint that checks the Auth0 permissions is the 'create users' endpoint, it doesn't really matter if we update the user's role in Auth0 or not; the role is checked internally in the API anyway.
 	- All endpoints that previously fetched the currently logged in user for authorisation (i.e., messaging endpoints checking the user isn't attempting to access someone else's messages) now use the user data returned by the `required_auth` decorator.

--- a/changelog/pr606.json
+++ b/changelog/pr606.json
@@ -1,0 +1,9 @@
+{
+  "pr_number": 606,
+  "changes": [
+    {
+      "change": "Changes",
+      "description": "Deleted the report update from 'edit user' and 'edit post' endpoints. Including the extra complication of updating reports in unrelated endpoints was bad practice. Each endpoint should be specific to its purpose. Now, in order to close reports, users need to make a request to the 'edit report' endpoint, as it should've been in the first place."
+    }
+  ]
+}

--- a/tests/test_posts.py
+++ b/tests/test_posts.py
@@ -222,22 +222,6 @@ def test_update_other_users_post_as_mod(
     assert post_text["text"] == post["text"]
 
 
-# Attempt to close the report on another user's post (with mod's JWT)
-def test_update_other_users_post_report_as_mod(
-    app_client, test_db, user_headers, dummy_request_data, dummy_users_data
-):
-    post = dummy_request_data["report_post"]
-    post["userId"] = dummy_users_data["user"]["internal"]
-    post["givenHugs"] = 2
-    response = app_client.patch(
-        "/posts/4", headers=user_headers["moderator"], data=json.dumps(post)
-    )
-    response_data = json.loads(response.data)
-
-    assert response_data["success"] is False
-    assert response.status_code == 403
-
-
 # Attempt to update the admin's post (with same admin's JWT)
 def test_update_own_post_as_admin(
     app_client, test_db, user_headers, dummy_request_data, dummy_users_data

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -29,8 +29,6 @@ import json
 
 import pytest
 
-from models import User, Report
-
 
 # Get Users by Type Tests ('/users/<type>', GET)
 # -------------------------------------------------------
@@ -527,33 +525,6 @@ def test_update_admin_settings_as_admin_invalid_settings(
     assert response_data["success"] is False
     assert response.status_code == 422
     assert get_response_data["user"]["refreshRate"] == 20
-
-
-def test_close_report_update_user_as_admin(
-    app_client, test_db, user_headers, dummy_users_data, dummy_request_data
-):
-    user = {**dummy_request_data["updated_unblock_user"]}
-    user["id"] = dummy_users_data["moderator"]["internal"]
-    user["closeReport"] = 6
-    response = app_client.patch(
-        f"/users/all/{dummy_users_data['admin']['internal']}",
-        headers=user_headers["admin"],
-        data=json.dumps(user),
-    )
-    response_data = json.loads(response.data)
-
-    assert response_data["success"] is True
-    assert response.status_code == 200
-
-    moderator = test_db.session.get(User, dummy_users_data["moderator"]["internal"])
-    report = test_db.session.get(Report, 6)
-
-    if not moderator or not report:
-        pytest.fail()
-
-    assert moderator.open_report is False
-    assert (report.closed) is True
-    assert report.dismissed is False
 
 
 # Get User's Posts Tests ('/users/all/<user_id>/posts', GET)


### PR DESCRIPTION
**Description**

Previously it was possible to close reports from the 'edit user' and 'edit post' endpoints. This is unnecessarily complicated and unclean as endpoints should stick to their specific purpose.

**Issue link**

--

**Expected behavior**

--

**Your solution**

Removed the 'closeReport' property and its handling from the endpoints specified above. Now, if admins want to close reports, they need to make a request to the 'edit report' endpoint.

Will break report closing when editing display name unless https://github.com/sendahug/send-hug-frontend/pull/1602 is merged first.

**Additional information**

--
