### PR TITLE
change: Moved all endpoint-specific code from db_helpers to the relevant endpoints.

### DIFF
--- a/changelog/pr609.json
+++ b/changelog/pr609.json
@@ -1,0 +1,13 @@
+{
+  "pr_number": 609,
+  "changes": [
+    {
+      "change": "Changes",
+      "description": "Moved all endpoint-specific code from the database helpers to the relevant endpoints. The database helpers should be generic and simply commit to the database, handle errors and close the current session, but previously they also dealt with model-specific actions (e.g., deleting messages, posts and threads). Now, the model/endpoint-specific code was moved to the relevant endpoints, and the database helpers only include the code for communicating with the database, handling errors raised by it, and closing the session once the update is done."
+    },
+    {
+      "change": "Changes",
+      "description": "Replaced the `delete_all` helper function with a function for bulk updating and deleting. While the old function required a delete target and the ID of the user whose items to should be deleted, the new function simple requires a list of `delete` statements to run and a list of objects that were updated and should be committed to the database. This allows us to perform multiple deletes and updates within the same session, and moves the responsibility for updating/deleting to the endpoint."
+    }
+  ]
+}

--- a/create_app.py
+++ b/create_app.py
@@ -1228,7 +1228,7 @@ def create_app(db_path: str = database_path) -> Flask:
             delete_stmt = delete(Message).where(
                 and_(Message.for_id == user_id, Message.from_deleted == db.true())
             )
-            messages_to_update = db.session.scalars(
+            messages_to_update: Sequence[Message] = db.session.scalars(
                 db.select(Message)
                 .filter(Message.for_id == user_id)
                 .filter(Message.from_deleted == db.false())
@@ -1294,7 +1294,7 @@ def create_app(db_path: str = database_path) -> Flask:
 
             # Fetch all the messages that need to be updated, then the threads
             # that need to be updated
-            messages_to_update: Sequence[Message] = db.session.scalars(
+            messages_to_update = db.session.scalars(
                 db.select(Message).filter(
                     or_(
                         and_(

--- a/create_app.py
+++ b/create_app.py
@@ -34,7 +34,7 @@ from datetime import datetime
 from flask import Flask, request, abort, jsonify
 from flask_cors import CORS
 from pywebpush import webpush, WebPushException  # type: ignore
-from sqlalchemy import Text, and_, or_
+from sqlalchemy import Text, and_, delete, or_
 
 from models import (
     database_path,
@@ -50,9 +50,9 @@ from models import (
     add as db_add,
     update as db_update,
     delete_object as db_delete,
-    delete_all as db_delete_all,
     update_multiple as db_update_multi,
     add_or_update_multiple as db_bulk_insert_update,
+    bulk_delete_and_update as db_bulk_delete_update,
 )
 from auth import (
     AuthError,
@@ -785,7 +785,7 @@ def create_app(db_path: str = database_path) -> Flask:
             abort(404)
 
         # Try to delete
-        db_delete_all("posts", user_id)
+        db_bulk_delete_update([delete(Post).where(Post.user_id == user_id)])
 
         return jsonify({"success": True, "userID": int(user_id), "deleted": post_count})
 
@@ -1220,6 +1220,28 @@ def create_app(db_path: str = database_path) -> Flask:
             # If there are no messages, abort
             if num_messages == 0:
                 abort(404)
+
+            # Separates messages that were deleted by the other user (and are
+            # thus okay to delete completely) from messages that weren't
+            # (so that these will only be deleted for one user rather than
+            # for both)
+            delete_stmt = delete(Message).where(
+                and_(Message.for_id == user_id, Message.from_deleted == db.true())
+            )
+            messages_to_update = db.session.scalars(
+                db.select(Message)
+                .filter(Message.for_id == user_id)
+                .filter(Message.from_deleted == db.false())
+            ).all()
+
+            # For each message that wasn't deleted by the other user, the
+            # value of for_deleted (indicating whether the user the message
+            # is for deleted it) is updated to True
+            for message in messages_to_update:
+                message.for_deleted = True
+
+            db_bulk_delete_update([delete_stmt], to_update=list(messages_to_update))
+
         # If the user is trying to clear their outbox
         if mailbox_type == "outbox":
             num_messages = db.session.scalar(
@@ -1228,6 +1250,28 @@ def create_app(db_path: str = database_path) -> Flask:
             # If there are no messages, abort
             if num_messages == 0:
                 abort(404)
+
+            # Separates messages that were deleted by the other user (and are
+            # thus okay to delete completely) from messages that weren't
+            # (so that these will only be deleted for one user rather than
+            # for both)
+            delete_stmt = delete(Message).where(
+                and_(Message.from_id == user_id, Message.for_deleted == db.true())
+            )
+            messages_to_update = db.session.scalars(
+                db.select(Message)
+                .filter(Message.from_id == user_id)
+                .filter(Message.for_deleted == db.false())
+            ).all()
+
+            # For each message that wasn't deleted by the other user, the
+            # value of from_deleted (indicating whether the user who wrote
+            # the message deleted it) is updated to True
+            for message in messages_to_update:
+                message.from_deleted = True
+
+            db_bulk_delete_update([delete_stmt], to_update=list(messages_to_update))
+
         # If the user is trying to clear their threads mailbox
         if mailbox_type == "threads":
             num_messages = db.session.scalar(
@@ -1248,8 +1292,74 @@ def create_app(db_path: str = database_path) -> Flask:
             if num_messages == 0:
                 abort(404)
 
-        # Try to clear the mailbox
-        db_delete_all(mailbox_type, user_id)
+            # Fetch all the messages that need to be updated, then the threads
+            # that need to be updated
+            messages_to_update: Sequence[Message] = db.session.scalars(
+                db.select(Message).filter(
+                    or_(
+                        and_(
+                            Message.for_id == user_id,
+                            Message.from_deleted == db.false(),
+                        ),
+                        and_(
+                            Message.from_id == user_id,
+                            Message.for_deleted == db.false(),
+                        ),
+                    )
+                )
+            ).all()
+
+            for message in messages_to_update:
+                if message.for_id == user_id:
+                    message.for_deleted = True
+                else:
+                    message.from_deleted = True
+
+            threads_to_update: Sequence[Thread] = db.session.scalars(
+                db.select(Thread).filter(
+                    or_(
+                        and_(
+                            Thread.user_1_id == user_id,
+                            Thread.user_2_deleted == db.false(),
+                        ),
+                        and_(
+                            Thread.user_2_id == user_id,
+                            Thread.user_1_deleted == db.false(),
+                        ),
+                    )
+                )
+            ).all()
+
+            for thread in threads_to_update:
+                if thread.user_1_id == user_id:
+                    thread.user_1_deleted = True
+                else:
+                    thread.user_2_deleted = True
+
+            # The compile the delete statements for everything that needs to be
+            # deleted.
+            delete_messages_stmt = delete(Message).where(
+                or_(
+                    and_(Message.for_id == user_id, Message.from_deleted == db.true()),
+                    and_(Message.from_id == user_id, Message.for_deleted == db.true()),
+                )
+            )
+
+            delete_threads_stmt = delete(Thread).where(
+                or_(
+                    and_(
+                        Thread.user_1_id == user_id, Thread.user_2_deleted == db.true()
+                    ),
+                    and_(
+                        Thread.user_2_id == user_id, Thread.user_1_deleted == db.true()
+                    ),
+                )
+            )
+
+            db_bulk_delete_update(
+                delete_stmts=[delete_messages_stmt, delete_threads_stmt],
+                to_update=[*messages_to_update, *threads_to_update],
+            )
 
         return jsonify(
             {"success": True, "userID": int(user_id), "deleted": num_messages}

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -43,6 +43,6 @@ from .db_helpers import (
     update,
     update_multiple,
     delete_object,
-    delete_all,
     add_or_update_multiple,
+    bulk_delete_and_update,
 )

--- a/models/db_helpers.py
+++ b/models/db_helpers.py
@@ -25,13 +25,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import List, Literal, Any, TypedDict, Union
+from typing import List, Any, TypedDict, Union
 
 from flask import abort
-from sqlalchemy import and_, or_, delete
+from sqlalchemy import Delete
 from sqlalchemy.exc import DataError, IntegrityError
 
-from .models import Post, Message, Thread, db
+from .models import db
 
 
 class DBReturnModel(TypedDict):
@@ -84,7 +84,6 @@ def update(obj: db.Model) -> DBReturnModel:  # type: ignore[name-defined]
     Updates an existing record.
 
     param obj: Updated object (User, Post or Message).
-    param params: dictionary of extra params for handling related objects
     """
     updated_object = {}
 
@@ -201,149 +200,28 @@ def delete_object(obj: db.Model) -> DBDeleteModel:  # type: ignore[name-defined]
     return {"success": True, "deleted": deleted}
 
 
-def delete_all(
-    type: Literal["posts", "inbox", "outbox", "thread", "threads"], id: int
-) -> DBDeleteModel:
+def bulk_delete_and_update(
+    delete_stmts: List[Delete],
+    to_update: List[db.Model] = [],  # type: ignore[name-defined]
+) -> DBBulkModel:
     """
-    Deletes all records that match a condition.
+    Run multiple delete statements and possible updates within the same
+    session.
 
-    param type: type of item to delete (posts or messages)
-    param id: ID of the user whose posts or messages need to be deleted.
+    param delete_stmts: Delete statements to run.
+    param to_update: Objects to update in the database.
     """
+    updated_objects = []
+
     # Try to delete the records
     try:
-        # If the type of objects to delete is posts, the ID is the
-        # user ID whose posts need to be deleted
-        if type == "posts":
-            delete(Post).where(Post.user_id == id)
-        # If the type of objects to delete is inbox, delete all messages
-        # for the user with that ID
-        if type == "inbox":
-            # Separates messages that were deleted by the other user (and are
-            # thus okay to delete completely) from messages that weren't
-            # (so that these will only be deleted for one user rather than
-            # for both)
-            delete(Message).where(
-                and_(Message.for_id == id, Message.from_deleted == db.true())
-            )
-            messages_to_update = db.session.scalars(
-                db.select(Message)
-                .filter(Message.for_id == id)
-                .filter(Message.from_deleted == db.false())
-            ).all()
-
-            # For each message that wasn't deleted by the other user, the
-            # value of for_deleted (indicating whether the user the message
-            # is for deleted it) is updated to True
-            for message in messages_to_update:
-                message.for_deleted = True
-        # If the type of objects to delete is outbox, delete all messages
-        # from the user with that ID
-        if type == "outbox":
-            # Separates messages that were deleted by the other user (and are
-            # thus okay to delete completely) from messages that weren't
-            # (so that these will only be deleted for one user rather than
-            # for both)
-            delete(Message).where(
-                and_(Message.from_id == id, Message.for_deleted == db.true())
-            )
-            messages_to_update = db.session.scalars(
-                db.select(Message)
-                .filter(Message.from_id == id)
-                .filter(Message.for_deleted == db.false())
-            ).all()
-
-            # For each message that wasn't deleted by the other user, the
-            # value of from_deleted (indicating whether the user who wrote
-            # the message deleted it) is updated to True
-            for message in messages_to_update:
-                message.from_deleted = True
-        # If the type of objects to delete is threads, delete all messages
-        # to and from the user with that ID
-        if type == "threads":
-            # Get all threads in which the user is involved
-            Threads = db.session.scalars(
-                db.select(Thread).filter(
-                    or_((Thread.user_1_id == id), (Thread.user_2_id == id))
-                )
-            ).all()
-            # List of thread IDs to delete
-            threads_to_delete: List[int] = []
-
-            # Delete the messages in each thread
-            for thread in Threads:
-                # Separates messages that were deleted by the other user (and
-                # are thus okay to delete completely) from messages that
-                # weren't (so that these will only be deleted for one user
-                # rather than for both)
-                delete(Message).where(
-                    and_(
-                        Message.thread == thread.id,
-                        or_(
-                            and_(
-                                (Message.for_id == id),
-                                Message.from_deleted == db.true(),
-                            ),
-                            and_(
-                                (Message.from_id == id),
-                                (Message.for_deleted == db.true()),
-                            ),
-                        ),
-                    )
-                )
-                messages_for_to_update = db.session.scalars(
-                    db.select(Message)
-                    .filter(Message.thread == thread.id)
-                    .filter(
-                        and_(
-                            (Message.for_id == id), (Message.from_deleted == db.false())
-                        )
-                    )
-                ).all()
-                messages_from_to_update = db.session.scalars(
-                    db.select(Message)
-                    .filter(Message.thread == thread.id)
-                    .filter(
-                        and_(
-                            (Message.from_id == id), (Message.for_deleted == db.false())
-                        )
-                    )
-                ).all()
-
-                # For each message that wasn't deleted by the other user, the
-                # value of for_deleted (indicating whether the user the message
-                # is for deleted it) is updated to True
-                for message in messages_for_to_update:
-                    message.for_deleted = True
-
-                # For each message that wasn't deleted by the other user, the
-                # value of from_deleted (indicating whether the user who wrote
-                # the message deleted it) is updated to True
-                for message in messages_from_to_update:
-                    message.from_deleted = True
-
-                # If there are no messages left in this thread, both users
-                # deleted all messages in it, so the thread can be added
-                # to the "to delete" list
-                if (
-                    len(messages_for_to_update) == 0
-                    and len(messages_from_to_update) == 0
-                ):
-                    threads_to_delete.append(thread.id)
-                else:
-                    # If the current user is user 1 in the threads table,
-                    # set their deleted value to true
-                    if thread.user_1_id == id:
-                        thread.user_1_deleted = True
-                    # Otherwise it's user 2, so set their deleted value
-                    # to true
-                    else:
-                        thread.user_2_deleted = True
-
-            # Then try to delete the threads that are okay to delete
-            delete(Thread).where(Thread.id.in_(threads_to_delete))
+        for delete_stmt in delete_stmts:
+            db.session.execute(delete_stmt)
 
         db.session.commit()
+
+        for obj in to_update:
+            updated_objects.append(obj.format())
     # If there's a database error
     except (DataError, IntegrityError) as err:
         db.session.rollback()
@@ -356,4 +234,4 @@ def delete_all(
     finally:
         db.session.close()
 
-    return {"success": True, "deleted": type}
+    return {"success": True, "resource": updated_objects}


### PR DESCRIPTION
**Description**

We currently have a lot of endpoint/model specific code in the `db_helpers`, which are supposed to be generic.

**Issue link**

--

**Expected behavior**

--

**Your solution**

Moved all endpoint-specific code to the relevant endpoints.

**Additional information**

--
