### PR TITLE
chore: Changed the way the database is reset between tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,7 @@ The site uses several tools to maximise compatibility:
 
 6. **PyWebPush** - This application uses pywebpush in order to handle push notifications. For more information, check their [GitHub repo](https://github.com/web-push-libs/pywebpush).
 
-7. **sh** - This application uses sh during testing (in order to handle the database). For more information, check the [sh PyPi page](https://pypi.org/project/sh/).
-
-8. **Coverage** - This application uses coverage in order to provide code coverage for testing. For more information, check the [Coverage documentation](https://coverage.readthedocs.io/en/coverage-5.2.1/).
+7. **Coverage** - This application uses coverage in order to provide code coverage for testing. For more information, check the [Coverage documentation](https://coverage.readthedocs.io/en/coverage-5.2.1/).
 
 ## Authentication
 

--- a/changelog/pr619.json
+++ b/changelog/pr619.json
@@ -1,0 +1,9 @@
+{
+  "pr_number": 619,
+  "changes": [
+    {
+      "change": "Chores",
+      "description": "Changed the way the database is reset between tests. Previously, we created a database dump file that was restored between tests. This was over-complicated and unscalable. Now, we populate the database once, before tests start; in order to ensure the database returns to its original state between tests, tests are run within a nested session, which is then rolled back between tests."
+    }
+  ]
+}

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,4 +7,3 @@ pytest==8.1.1
 pytest-mock==3.14.0
 pytest-cov==5.0.0
 pytest-asyncio==0.23.6
-sh==2.0.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,4 @@ per-file-ignores = __init__.py:F401
 addopts =
 	--cov-config=.coveragerc
 	--cov=.
+asyncio_mode=auto

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ def app_client(test_config: SAHConfig):
 
 @pytest.fixture(scope="session")
 def db(test_config: SAHConfig):
-    """Create a snapshot of the test database to restore between tests"""
+    """Creates the database and inserts the test data."""
     BaseModel.metadata.drop_all(test_config.db.engine)
     # create all tables
     BaseModel.metadata.create_all(test_config.db.engine)
@@ -89,7 +89,13 @@ def db(test_config: SAHConfig):
 
 @pytest.fixture(scope="function")
 def test_db(db):
-    """Restore the test database from the db snapshot"""
+    """
+    Generates the session to use in tests. Once tests are done, rolls
+    back the transaction and closes the session. Also updates the values
+    of all sequences.
+    Credit to gmassman; the code is mostly copied from
+    https://github.com/gmassman/fsa-rollback-per-test-example.
+    """
     connection = db.engine.connect()
     transaction = connection.begin_nested()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime
 
 import pytest
+from pytest_mock import MockerFixture
 from sqlalchemy.orm import scoped_session, sessionmaker
 
 from create_app import create_app
@@ -70,9 +71,10 @@ def test_config():
 
 
 @pytest.fixture(scope="session")
-def app_client(test_config: SAHConfig):
+def app_client(test_config: SAHConfig, session_mocker: MockerFixture):
     """Get the test client for the test app"""
     app = create_app(config=test_config)
+    session_mocker.patch("pywebpush.webpush")
     yield app.test_client()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,12 +4,12 @@ import json
 from datetime import datetime
 
 import pytest
-from sh import pg_restore, pg_dump  # type: ignore
+from sqlalchemy.orm import scoped_session, sessionmaker
 
 from create_app import create_app
 from config import SAHConfig
 from models.models import BaseModel
-from tests.data_models import create_data, DATETIME_PATTERN
+from tests.data_models import create_data, DATETIME_PATTERN, update_sequences
 
 AUTH0_DOMAIN = os.environ.get("AUTH0_DOMAIN", "")
 API_AUDIENCE = os.environ.get("API_AUDIENCE", "")
@@ -77,52 +77,41 @@ def app_client(test_config: SAHConfig):
 
 
 @pytest.fixture(scope="session")
-def setup_db_dump_file(test_config: SAHConfig):
+def db(test_config: SAHConfig):
     """Create a snapshot of the test database to restore between tests"""
     BaseModel.metadata.drop_all(test_config.db.engine)
     # create all tables
     BaseModel.metadata.create_all(test_config.db.engine)
     create_data(test_config.db)
-    pg_dump(
-        "test_sah",
-        "-Fc",
-        "-c",
-        "-O",
-        "-x",
-        "-f",
-        "tests/capstone_db",
-        "-h",
-        "localhost",
-        "-p",
-        "5432",
-        "-U",
-        "postgres",
-    )
+
+    yield test_config.db
 
 
 @pytest.fixture(scope="function")
-def test_db(setup_db_dump_file, test_config: SAHConfig):
+def test_db(db):
     """Restore the test database from the db snapshot"""
-    pg_restore(
-        "-d",
-        "test_sah",
-        "tests/capstone_db",
-        "--clean",
-        "--if-exists",
-        "-Fc",
-        "--no-owner",
-        "-h",
-        "localhost",
-        "-p",
-        "5432",
-        "-U",
-        "postgres",
+    connection = db.engine.connect()
+    transaction = connection.begin_nested()
+
+    db.session_factory = sessionmaker(
+        bind=connection,
+        join_transaction_mode="create_savepoint",
     )
 
-    try:
-        yield test_config.db
-    finally:
-        test_config.db.session.close()
+    db.session = scoped_session(session_factory=db.session_factory)
+
+    update_sequences(db)
+
+    db.session.begin_nested()
+
+    yield db
+
+    # Delete the session
+    db.session.remove()
+
+    # Rollback the transaction and return the connection to the pool
+    transaction.rollback()
+    connection.close()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,7 @@ def test_db(db, mocker: MockerFixture):
 
     db.session.begin_nested()
     mocker.patch("pywebpush.webpush")
+    mocker.patch("create_app.webpush")
 
     yield db
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,10 +71,9 @@ def test_config():
 
 
 @pytest.fixture(scope="session")
-def app_client(test_config: SAHConfig, session_mocker: MockerFixture):
+def app_client(test_config: SAHConfig):
     """Get the test client for the test app"""
     app = create_app(config=test_config)
-    session_mocker.patch("pywebpush.webpush")
     yield app.test_client()
 
 
@@ -90,7 +89,7 @@ def db(test_config: SAHConfig):
 
 
 @pytest.fixture(scope="function")
-def test_db(db):
+def test_db(db, mocker: MockerFixture):
     """
     Generates the session to use in tests. Once tests are done, rolls
     back the transaction and closes the session. Also updates the values
@@ -111,6 +110,7 @@ def test_db(db):
     update_sequences(db)
 
     db.session.begin_nested()
+    mocker.patch("pywebpush.webpush")
 
     yield db
 

--- a/tests/data_models.py
+++ b/tests/data_models.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import json
 
 from sqlalchemy import select, text
 
@@ -12,6 +13,7 @@ from models.models import (
     Notification,
     Filter,
     Role,
+    NotificationSub,
 )
 from models.db import SendADatabase
 
@@ -1644,7 +1646,51 @@ def create_notifications(db: SendADatabase):
         db.session.close()
 
 
-# TODO: Add subscriptions
+def create_subscriptions(db: SendADatabase):
+    """Creates the push subscriptions in the database"""
+    sub_1 = NotificationSub(
+        id=1,
+        user=1,
+        endpoint="https://fcm.googleapis.com/fcm/send/epyhl2GD",
+        subscription_data=json.dumps(
+            {
+                "endpoint": "https://fcm.googleapis.com/fcm/send/epyhl2GD",
+                "expirationTime": None,
+                "keys": {"p256dh": "fdsfd", "auth": "dfs"},
+            }
+        ),
+    )
+    sub_2 = NotificationSub(
+        id=2,
+        user=5,
+        endpoint="https://fcm.googleapis.com/fcm/send/epyhl2GD",
+        subscription_data=json.dumps(
+            {
+                "endpoint": "https://fcm.googleapis.com/fcm/send/epyhl2GD",
+                "expirationTime": None,
+                "keys": {"p256dh": "fdsfd", "auth": "dfs"},
+            }
+        ),
+    )
+    sub_3 = NotificationSub(
+        id=3,
+        user=4,
+        endpoint="https://fcm.googleapis.com/fcm/send/epyhl2GD",
+        subscription_data=json.dumps(
+            {
+                "endpoint": "https://fcm.googleapis.com/fcm/send/epyhl2GD",
+                "expirationTime": None,
+                "keys": {"p256dh": "fdsfd", "auth": "dfs"},
+            }
+        ),
+    )
+
+    try:
+        db.session.add_all([sub_1, sub_2, sub_3])
+        db.session.execute(text("ALTER SEQUENCE subscriptions_id_seq RESTART WITH 4;"))
+        db.session.commit()
+    finally:
+        db.session.close()
 
 
 def create_data(db: SendADatabase):
@@ -1658,6 +1704,6 @@ def create_data(db: SendADatabase):
     create_messages(db)
     create_reports(db)
     create_notifications(db)
-    # create_subscriptions(db)
+    create_subscriptions(db)
 
     db.session.close()

--- a/tests/data_models.py
+++ b/tests/data_models.py
@@ -1693,6 +1693,24 @@ def create_subscriptions(db: SendADatabase):
         db.session.close()
 
 
+def update_sequences(db: SendADatabase):
+    """Updates the values of all sequences."""
+    try:
+        db.session.execute(text("ALTER SEQUENCE filters_id_seq RESTART WITH 3;"))
+        db.session.execute(text("ALTER SEQUENCE permissions_id_seq RESTART WITH 16;"))
+        db.session.execute(text("ALTER SEQUENCE roles_id_seq RESTART WITH 6;"))
+        db.session.execute(text("ALTER SEQUENCE users_id_seq RESTART WITH 21;"))
+        db.session.execute(text("ALTER SEQUENCE posts_id_seq RESTART WITH 46;"))
+        db.session.execute(text("ALTER SEQUENCE messages_id_seq RESTART WITH 27;"))
+        db.session.execute(text("ALTER SEQUENCE threads_id_seq RESTART WITH 9;"))
+        db.session.execute(text("ALTER SEQUENCE reports_id_seq RESTART WITH 45;"))
+        db.session.execute(text("ALTER SEQUENCE notifications_id_seq RESTART WITH 96;"))
+        db.session.execute(text("ALTER SEQUENCE subscriptions_id_seq RESTART WITH 4;"))
+        db.session.commit()
+    finally:
+        db.session.close()
+
+
 def create_data(db: SendADatabase):
     """Creates the data in the test database."""
     create_filters(db)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -270,7 +270,6 @@ async def test_post_subscription_as_user(
     assert response_data["success"] is True
     assert response.status_code == 200
     assert response_data["subscribed"] == "shirb"
-    assert response_data["subId"] == 1
 
 
 # Attempt to create push subscription with a moderator's JWT
@@ -288,7 +287,6 @@ async def test_post_subscription_as_mod(
     assert response_data["success"] is True
     assert response.status_code == 200
     assert response_data["subscribed"] == "user52"
-    assert response_data["subId"] == 1
 
 
 # Attempt to create push subscription with an admin's JWT
@@ -306,7 +304,6 @@ async def test_post_subscription_as_admin(
     assert response_data["success"] is True
     assert response.status_code == 200
     assert response_data["subscribed"] == "user14"
-    assert response_data["subId"] == 1
 
 
 # Attempt to create push subscription with an admin's JWT
@@ -378,13 +375,6 @@ async def test_update_subscription_malformed_auth(
 async def test_update_subscription_as_user(
     app_client, test_db, user_headers, dummy_request_data
 ):
-    # Create the subscription
-    await app_client.post(
-        "/notifications",
-        data=json.dumps(dummy_request_data["new_subscription"]),
-        headers=user_headers["user"],
-    )
-    # Then update it
     updated_subscription: dict[str, Any] = {**dummy_request_data["new_subscription"]}
     updated_subscription["id"] = 1
     response = await app_client.patch(
@@ -405,17 +395,10 @@ async def test_update_subscription_as_user(
 async def test_update_subscription_as_mod(
     app_client, test_db, user_headers, dummy_request_data
 ):
-    # Create the subscription
-    await app_client.post(
-        "/notifications",
-        data=json.dumps(dummy_request_data["new_subscription"]),
-        headers=user_headers["moderator"],
-    )
-    # Then update it
     updated_subscription: dict[str, Any] = {**dummy_request_data["new_subscription"]}
-    updated_subscription["id"] = 1
+    updated_subscription["id"] = 2
     response = await app_client.patch(
-        "/notifications/1",
+        "/notifications/2",
         data=json.dumps(dummy_request_data["new_subscription"]),
         headers=user_headers["moderator"],
     )
@@ -424,7 +407,7 @@ async def test_update_subscription_as_mod(
     assert response_data["success"] is True
     assert response.status_code == 200
     assert response_data["subscribed"] == "user52"
-    assert response_data["subId"] == 1
+    assert response_data["subId"] == 2
 
 
 # Attempt to create push subscription with an admin's JWT
@@ -432,17 +415,10 @@ async def test_update_subscription_as_mod(
 async def test_update_subscription_as_admin(
     app_client, test_db, user_headers, dummy_request_data
 ):
-    # Create the subscription
-    await app_client.post(
-        "/notifications",
-        data=json.dumps(dummy_request_data["new_subscription"]),
-        headers=user_headers["admin"],
-    )
-    # Then update it
     updated_subscription: dict[str, Any] = {**dummy_request_data["new_subscription"]}
-    updated_subscription["id"] = 1
+    updated_subscription["id"] = 3
     response = await app_client.patch(
-        "/notifications/1",
+        "/notifications/3",
         data=json.dumps(dummy_request_data["new_subscription"]),
         headers=user_headers["admin"],
     )
@@ -451,7 +427,7 @@ async def test_update_subscription_as_admin(
     assert response_data["success"] is True
     assert response.status_code == 200
     assert response_data["subscribed"] == "user14"
-    assert response_data["subId"] == 1
+    assert response_data["subId"] == 3
 
 
 # Attempt to create push subscription with an admin's JWT

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -766,6 +766,7 @@ async def test_user_hugs(app_client, test_db, user_headers):
         "/users/all/1/hugs", headers=user_headers["moderator"]
     )
     response_data = await response.get_json()
+    print(response_data)
 
     assert response_data["success"] is True
     assert response.status_code == 200

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -766,7 +766,6 @@ async def test_user_hugs(app_client, test_db, user_headers):
         "/users/all/1/hugs", headers=user_headers["moderator"]
     )
     response_data = await response.get_json()
-    print(response_data)
 
     assert response_data["success"] is True
     assert response.status_code == 200


### PR DESCRIPTION
**Description**

Right now we're restoring the database between tests. That's overcomplicated and unscalable.

**Issue link**

--

**Expected behavior**

--

**Your solution**

Switched tests to use a session fixture (similar to what `pytest-flask-sqlalchemy` does), which is then rolled back in the end of each test.

**Additional information**

--
